### PR TITLE
added basic punctuation keys . , ?

### DIFF
--- a/nuvox/config/config.py
+++ b/nuvox/config/config.py
@@ -8,6 +8,9 @@ class Config:
 
     # keyboard layout
     KEY_LIST = nuvox_standard_keyboard
+    FIXED_KEY_ID_TO_PUNCTUATION = {'7': '.',
+                                   '8': ',',
+                                   '9': '?'}
 
     # display settings
     DISPLAY_HEIGHT = 600

--- a/nuvox/config/keyboard_layouts.py
+++ b/nuvox/config/keyboard_layouts.py
@@ -22,7 +22,7 @@ nuvox_standard_keyboard = [Key(x1=0/8, y1=0/8, w=7/8, h=1/8, key_id='display', c
                            Key(x1=7/8, y1=2/4, w=1/8, h=1/4, key_id='delete', contents=['del']),
 
                            Key(x1=0/8, y1=3/4, w=1/8, h=1/4, key_id='settings_switch', contents=['⚙']),
-                           Key(x1=1/8, y1=3/4, w=2/8, h=1/4, key_id='7', contents=['p', 'q', 'r', 's']),
-                           Key(x1=3/8, y1=3/4, w=2/8, h=1/4, key_id='8', contents=['t', 'u', 'v']),
-                           Key(x1=5/8, y1=3/4, w=2/8, h=1/4, key_id='9', contents=['w', 'x', 'y', 'z']),
+                           Key(x1=1/8, y1=3/4, w=2/8, h=1/4, key_id='7', contents=['p', 'q', 'r', 's', '.']),
+                           Key(x1=3/8, y1=3/4, w=2/8, h=1/4, key_id='8', contents=['t', 'u', 'v', ',']),
+                           Key(x1=5/8, y1=3/4, w=2/8, h=1/4, key_id='9', contents=['w', 'x', 'y', 'z', '?']),
                            Key(x1=7/8, y1=3/4, w=1/8, h=1/4, key_id='clear', contents=['clr'])]

--- a/nuvox/controller.py
+++ b/nuvox/controller.py
@@ -48,9 +48,6 @@ class Controller:
                                           'delete': self.on_del_key,
                                           'clear': self.on_clear_key,
                                           'exit': self.on_exit_key,
-                                          ',': lambda: self.on_punctuation_key(','),
-                                          '.': lambda: self.on_punctuation_key('.'),
-                                          '?': lambda: self.on_punctuation_key('?'),
                                           'suggestion_1': lambda: self.on_suggestion_key(1),
                                           'suggestion_2': lambda: self.on_suggestion_key(2),
                                           'suggestion_3': lambda: self.on_suggestion_key(3),
@@ -130,7 +127,8 @@ class Controller:
                                                                     key_id_sequence=self.key_trace)
         if ranked_predictions:
             self.update_display_text(' '.join([self.current_text, ranked_predictions[0]]))
-            self.update_suggestions(suggestions=ranked_predictions[1:], suggestion_indices=[0, 1, 2])
+            suggestions = ranked_predictions[1:]
+            self.update_suggestions(suggestions=suggestions, suggestion_indices=list(range(min(3, len(suggestions)))))
             self.view.flash_pred_word(key_id=key_in_focus.key_id, word=ranked_predictions[0])
         self.view.reset_widget_colour(key_id=key_in_focus.key_id)
         self.key_trace.clear()
@@ -161,6 +159,8 @@ class Controller:
         self.update_suggestions(suggestions=['']*3, suggestion_indices=[])
 
     def update_display_text(self, text):
+        if text and (text[-1] in self.config.FIXED_KEY_ID_TO_PUNCTUATION.values()):
+            text = ''.join([text[:-2], text[-1]])  # filter space before punc e.g. 'hello .' --> 'hello.'
         self.current_text = text
         self.view.update_display_text(new_text=text)
 
@@ -193,9 +193,6 @@ class Controller:
             widget = self.view.key_id_to_widget.get('suggestion_{}'.format(display_idx+1))
             if widget:
                 widget.configure(text=suggestions[suggestion_idx])
-
-    def on_punctuation_key(self, char):
-        self.update_display_text(''.join([self.current_text, char]))
 
     def get_gaze_relative_to_window(self):
         top_level = self.view.toplevel

--- a/nuvox/services/predictive_text.py
+++ b/nuvox/services/predictive_text.py
@@ -39,6 +39,11 @@ class PredictiveText:
         if not key_id_sequence:
             return []
 
+        # Phase 0 - check if punctuation key was selected
+        intended_punctuation = self.get_intended_punctuation(key_id_sequence)
+        if intended_punctuation:
+            return [intended_punctuation]
+
         # Phase 1) Get a dict mapping all possibly intended words to their probability based on the trace ONLY
         possible_word_to_prob = self.trace_algorithm.get_possible_word_to_trace_prob(key_id_sequence=key_id_sequence)
 
@@ -59,6 +64,23 @@ class PredictiveText:
         print('Key trace: \n ', key_id_sequence, '\n ranked suggestions: ', ranked_suggestions)
 
         return ranked_suggestions
+
+    def get_intended_punctuation(self, key_id_sequence):
+        """
+        Config contains a hardcoded mapping from key_id to punctuation
+        Parameters
+        ----------
+        key_id_sequence: list[str]
+
+        Returns
+        -------
+        punctuation: str
+            or None if no punctation
+        """
+        if len(set(key_id_sequence)) == 1:
+            key_id = key_id_sequence[0]
+            punctuation = self.config.FIXED_KEY_ID_TO_PUNCTUATION.get(key_id)
+            return punctuation
 
     def remove_blacklisted_keys(self, key_id_sequence):
         """ Remove key_ids from sequence that are to be ignored e.g. the blank key at center of screen"""


### PR DESCRIPTION
In this PR I re-added the ability to select the basic punctuation keys (. , ?). Instead of occupying their own key (waste of space) they fit occupy the 7, 8 and 9 keys. To select the punctuation key you simply look at that key for the full activate + deactivate swype without looking at any other keys in between. This works for those keys becasuse you can't spell any proper words by looking at only that key anyway 
